### PR TITLE
Evitar subir archivos con información personal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+desktop.ini
+Thumbs.db

--- a/1644-Logica de Programacion_Primeros Pasos-aula1/desktop.ini
+++ b/1644-Logica de Programacion_Primeros Pasos-aula1/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=Esta pasta está compartilhada on-line.
-IconFile=C:\Program Files\Google\Drive\googledrivesync.exe
-IconIndex=16
-    


### PR DESCRIPTION
Actualmente el código del aula 1 de lógica de programación expone
accidentalmente información personal del autor en el archivo
desktop.ini. Para evitar futuras filtraciones este PR agregó
desktop.ini a la lista de exclusiones de .git.

Adicionalmente, se agregó .DS_STORE y Thumbs.db a las exclusiones,
para evitar que se suba nuevamente un archivo de la shell
del explorador de archivos.

Saludos, Eduen Sarceño